### PR TITLE
[Refactor/#62] 지남력 퀴즈 폼 분리 및 uiState를 변경합니다.

### DIFF
--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/component/quizform/PersistenceQuizForm.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/component/quizform/PersistenceQuizForm.kt
@@ -1,0 +1,90 @@
+package com.moa.app.feature.senior.quiz.component.quizform
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moa.app.designsystem.component.core.button.MaQuizButton
+import com.moa.app.designsystem.component.core.button.QuizButtonState
+import com.moa.app.designsystem.theme.MoaTheme
+import com.moa.app.feature.senior.R
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+fun PersistenceQuizForm(
+    modifier: Modifier = Modifier,
+    questionContent: String,
+    answerOptions: ImmutableList<String>,
+    selectedAnswerIndex: Int?,
+    onOptionSelected: (Int) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Box(
+            contentAlignment = Alignment.CenterStart,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(32.dp))
+                .background(MoaTheme.colors.coolGray98)
+                .padding(vertical = 24.dp, horizontal = 32.dp),
+        ) {
+            Text(
+                text = questionContent,
+                color = MoaTheme.colors.black,
+                style = MoaTheme.typography.title2Semibold,
+            )
+        }
+
+        Image(
+            painter = painterResource(R.drawable.img_quiz_character_top),
+            contentDescription = null,
+            modifier = Modifier.align(alignment = Alignment.End),
+        )
+
+        answerOptions.forEachIndexed { index, option ->
+            val buttonState = when (selectedAnswerIndex) {
+                null -> QuizButtonState.DEFAULT
+                index -> QuizButtonState.SELECTED
+                else -> QuizButtonState.UNSELECTED
+            }
+
+            MaQuizButton(
+                onClick = { onOptionSelected(index) },
+                state = buttonState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+            ) {
+                Text(
+                    text = option,
+                    style = MoaTheme.typography.body1Semibold,
+                    modifier = Modifier.padding(vertical = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewPersistenceQuizForm() {
+    PersistenceQuizForm(
+        questionContent = "오늘은 몇 년도인가요?",
+        answerOptions = persistentListOf("2025년", "2022년", "2020년"),
+        selectedAnswerIndex = null,
+        onOptionSelected = {},
+    )
+}

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/persistence/PersistenceQuizScreen.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/persistence/PersistenceQuizScreen.kt
@@ -1,44 +1,30 @@
 package com.moa.app.feature.senior.quiz.persistence
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.moa.app.designsystem.component.core.button.MaButton
-import com.moa.app.designsystem.component.core.button.MaQuizButton
-import com.moa.app.designsystem.component.core.button.QuizButtonState
 import com.moa.app.designsystem.component.product.dialog.MaAlertDialog
 import com.moa.app.designsystem.component.product.topbar.MaStepProgressTopAppBar
 import com.moa.app.designsystem.theme.MoaTheme
 import com.moa.app.domain.quiz.model.PersistenceQuiz
 import com.moa.app.domain.quiz.model.QuizCategory
-import com.moa.app.feature.senior.R
 import com.moa.app.feature.senior.quiz.component.QuizLoadContent
 import com.moa.app.feature.senior.quiz.component.QuizResultDialog
+import com.moa.app.feature.senior.quiz.component.QuizSlideAnimation
+import com.moa.app.feature.senior.quiz.component.quizform.PersistenceQuizForm
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
@@ -48,42 +34,39 @@ fun PersistenceQuizScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     BackHandler(enabled = true, onBack = viewModel::onBackClick)
 
-    when (val uiState = uiState) {
-        is PersistenceQuizUiState.Loading -> QuizLoadContent(QuizCategory.PERSISTENCE)
-        is PersistenceQuizUiState.Error -> {}
-        is PersistenceQuizUiState.Success -> {
-            PersistenceQuizContent(
-                uiState = uiState,
-                onBackClick = viewModel::onBackClick,
-                onOptionSelected = viewModel::selectAnswer,
-                onContinueClick = viewModel::checkAnswer,
-            )
+    if (uiState.isLoading && uiState.quizzes.isEmpty()) {
+        QuizLoadContent(QuizCategory.PERSISTENCE)
+    } else {
+        PersistenceQuizContent(
+            uiState = uiState,
+            onBackClick = viewModel::onBackClick,
+            onOptionSelected = viewModel::selectAnswer,
+            onContinueClick = viewModel::checkAnswer,
+        )
+    }
 
-            if (uiState.showResultDialog && uiState.dialogResult != null) {
-                QuizResultDialog(
-                    isCorrect = uiState.dialogResult.isCorrect,
-                    correctAnswer = uiState.dialogResult.correctAnswer,
-                )
-            }
-
-            if (uiState.exitDialog) {
-                MaAlertDialog(
-                    title = "퀴즈를 그만두시나요?",
-                    content = "그만두면 지금까지\n푼 퀴즈는 저장되지 않아요.",
-                    confirmButtonText = "계속 풀기",
-                    dismissButtonText = "그만두기",
-                    onConfirm = viewModel::onHideExitDialog,
-                    onDismiss = viewModel::exitQuiz,
-                    onDialogDismissRequest = viewModel::onHideExitDialog,
-                )
-            }
+    if (uiState.showResultDialog) {
+        uiState.quizResult?.let { result ->
+            QuizResultDialog(isCorrect = result.isCorrect, correctAnswer = result.correctAnswer)
         }
+    }
+
+    if (uiState.showExitDialog) {
+        MaAlertDialog(
+            title = "퀴즈를 그만두시나요?",
+            content = "그만두면 지금까지\n푼 퀴즈는 저장되지 않아요.",
+            confirmButtonText = "계속 풀기",
+            dismissButtonText = "그만두기",
+            onConfirm = viewModel::onHideExitDialog,
+            onDismiss = viewModel::exitQuiz,
+            onDialogDismissRequest = viewModel::onHideExitDialog,
+        )
     }
 }
 
 @Composable
 private fun PersistenceQuizContent(
-    uiState: PersistenceQuizUiState.Success,
+    uiState: PersistenceQuizUiState,
     onOptionSelected: (Int) -> Unit,
     onContinueClick: () -> Unit,
     onBackClick: () -> Unit,
@@ -100,72 +83,18 @@ private fun PersistenceQuizContent(
 
         Spacer(modifier = Modifier.height(28.dp))
 
-        AnimatedContent(
-            modifier = Modifier.weight(1f),
-            targetState = uiState.currentQuestionIndex,
-            label = "QuizSlideAnimation",
-            transitionSpec = {
-                (slideIntoContainer(
-                    animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
-                    towards = AnimatedContentTransitionScope.SlideDirection.Start
-                ) togetherWith slideOutOfContainer(
-                    animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
-                    towards = AnimatedContentTransitionScope.SlideDirection.Start
-                ))
-                    .using(SizeTransform(clip = true))
-            },
-        ) { targetIndex ->
-            key(targetIndex) {
-                val question = uiState.quizzes[targetIndex]
-                val quizText = question.questionContent
-
-                Column(
+        uiState.currentQuiz?.let { targetQuiz ->
+            QuizSlideAnimation(
+                targetState = targetQuiz,
+                modifier = Modifier.weight(1f),
+            ) { question ->
+                PersistenceQuizForm(
                     modifier = Modifier.padding(horizontal = 20.dp),
-                ) {
-                    Box(
-                        contentAlignment = Alignment.CenterStart,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(
-                                color = MoaTheme.colors.coolGray98,
-                                shape = RoundedCornerShape(32.dp),
-                            )
-                            .padding(vertical = 24.dp, horizontal = 32.dp),
-                    ) {
-                        Text(
-                            text = quizText,
-                            color = MoaTheme.colors.black,
-                            style = MoaTheme.typography.title2Semibold,
-                        )
-                    }
-
-                    Image(
-                        painter = painterResource(R.drawable.img_quiz_character_top),
-                        contentDescription = null,
-                        modifier = Modifier.align(alignment = Alignment.End)
-                    )
-
-                    question.answerOptions.forEachIndexed { index, option ->
-                        val buttonState = when (uiState.selectedAnswerIndex) {
-                            null -> QuizButtonState.DEFAULT
-                            index -> QuizButtonState.SELECTED
-                            else -> QuizButtonState.UNSELECTED
-                        }
-
-                        MaQuizButton(
-                            onClick = { onOptionSelected(index) },
-                            state = buttonState,
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text(
-                                text = option,
-                                style = MoaTheme.typography.body1Semibold,
-                                modifier = Modifier.padding(vertical = 16.dp),
-                            )
-                        }
-                        Spacer(Modifier.height(8.dp))
-                    }
-                }
+                    questionContent = question.questionContent,
+                    answerOptions = question.answerOptions,
+                    selectedAnswerIndex = uiState.selectedAnswerIndex,
+                    onOptionSelected = onOptionSelected,
+                )
             }
         }
 
@@ -190,41 +119,41 @@ private fun PersistenceQuizContent(
 @Composable
 private fun Preview() {
     PersistenceQuizContent(
-        uiState = PersistenceQuizUiState.Success(
+        uiState = PersistenceQuizUiState.INIT.copy(
             quizzes = persistentListOf(
                 PersistenceQuiz(
                     id = 1,
                     type = QuizCategory.PERSISTENCE,
-                    questionFormat = "오늘은 몇 년도인가요?",
-                    questionContent = "",
+                    questionFormat = "",
+                    questionContent = "오늘은 몇 년도인가요?",
                     answer = "2025년",
                     answerOptions = persistentListOf("2025년", "2022년", "2020년"),
                 ),
                 PersistenceQuiz(
                     id = 1,
                     type = QuizCategory.PERSISTENCE,
-                    questionFormat = "오늘은 몇 년도인가요?",
-                    questionContent = "",
+                    questionFormat = "",
+                    questionContent = "오늘은 몇 년도인가요?",
                     answer = "2025년",
                     answerOptions = persistentListOf("2025년", "2022년", "2020년"),
                 ),
                 PersistenceQuiz(
                     id = 1,
                     type = QuizCategory.PERSISTENCE,
-                    questionFormat = "오늘은 몇 년도인가요?",
-                    questionContent = "",
+                    questionFormat = "",
+                    questionContent = "오늘은 몇 년도인가요?",
                     answer = "2025년",
                     answerOptions = persistentListOf("2025년", "2022년", "2020년"),
                 ),
                 PersistenceQuiz(
                     id = 1,
                     type = QuizCategory.PERSISTENCE,
-                    questionFormat = "오늘은 몇 년도인가요?",
-                    questionContent = "",
+                    questionFormat = "",
+                    questionContent = "오늘은 몇 년도인가요?",
                     answer = "2025년",
                     answerOptions = persistentListOf("2025년", "2022년", "2020년"),
                 ),
-            )
+            ),
         ),
         onOptionSelected = {},
         onContinueClick = {},

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/persistence/PersistenceQuizViewModel.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/persistence/PersistenceQuizViewModel.kt
@@ -3,12 +3,17 @@ package com.moa.app.feature.senior.quiz.persistence
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.moa.app.domain.quiz.model.LinguisticQuiz
 import com.moa.app.domain.quiz.model.PersistenceQuiz
 import com.moa.app.domain.quiz.model.QuizCategory
+import com.moa.app.domain.quiz.model.QuizScore
 import com.moa.app.domain.quiz.usecase.FetchQuizUseCase
+import com.moa.app.domain.quiz.usecase.UploadQuizScoreUseCase
+import com.moa.app.feature.senior.quiz.model.QuizResult
 import com.moa.app.navigation.Navigator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -25,34 +30,35 @@ import javax.inject.Inject
 class PersistenceQuizViewModel @Inject constructor(
     private val navigator: Navigator,
     private val fetchQuizUseCase: FetchQuizUseCase,
+    private val uploadQuizScoreUseCase: UploadQuizScoreUseCase,
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<PersistenceQuizUiState> = MutableStateFlow(PersistenceQuizUiState.Loading)
+    private val _uiState = MutableStateFlow(PersistenceQuizUiState.INIT)
     val uiState: StateFlow<PersistenceQuizUiState> = _uiState.asStateFlow()
 
     init {
-        loadQuizzes()
+        loadPersistenceQuizzes()
     }
 
-    private fun loadQuizzes() {
+    private fun loadPersistenceQuizzes() {
         viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
             val minLoadingTime = async { delay(2000L) }
-            val quizzesDeferred = async {
-                fetchQuizUseCase(QuizCategory.PERSISTENCE)
-            }
+            val quizzesDeferred = async { fetchQuizUseCase(QuizCategory.PERSISTENCE) }
             awaitAll(minLoadingTime, quizzesDeferred)
             quizzesDeferred.await().fold(
                 onSuccess = { quizzes ->
                     val persistenceQuizzes = quizzes.filterIsInstance<PersistenceQuiz>()
                     _uiState.update {
-                        PersistenceQuizUiState.Success(quizzes = persistenceQuizzes.toImmutableList())
+                        it.copy(
+                            isLoading = false,
+                            quizzes = persistenceQuizzes.toImmutableList(),
+                        )
                     }
                 },
                 onFailure = { t ->
-                    _uiState.update {
-                        PersistenceQuizUiState.Error(message = "퀴즈가 존재하지 않습니다.")
-                    }
-                    Timber.tag("PersistenceQuizViewModel").e("loadQuizzes: $t")
+                    Timber.e("loadQuizzes failed: $t")
+                    _uiState.update { it.copy(isLoading = false) }
                 },
             )
         }
@@ -60,27 +66,23 @@ class PersistenceQuizViewModel @Inject constructor(
 
     fun selectAnswer(selectedAnswerIndex: Int) {
         _uiState.update {
-            if (it is PersistenceQuizUiState.Success && !it.showResultDialog) {
-                it.copy(selectedAnswerIndex = selectedAnswerIndex)
-            } else {
-                it
-            }
+            if (it.showResultDialog || it.isLoading) return@update it
+            it.copy(selectedAnswerIndex = selectedAnswerIndex)
         }
     }
 
     fun checkAnswer() {
         _uiState.update {
-            if (it !is PersistenceQuizUiState.Success || it.showResultDialog) return@update it
+            if (it.showResultDialog || it.isLoading) return@update it
             val selectedAnswerIndex = it.selectedAnswerIndex ?: return@update it
             val currentQuiz = it.quizzes.getOrNull(it.currentQuestionIndex) ?: return@update it
             val isCorrect = currentQuiz.isAnswerCorrect(selectedAnswerIndex)
+            val correctAnswer = if (isCorrect) "" else currentQuiz.answer
 
             it.copy(
                 showResultDialog = true,
-                dialogResult = DialogResult(
-                    isCorrect = isCorrect,
-                    correctAnswer = if (isCorrect) "" else currentQuiz.answer,
-                ),
+                quizResult = QuizResult(isCorrect = isCorrect, correctAnswer = correctAnswer),
+                correctCount = if (isCorrect) it.correctCount + 1 else it.correctCount,
             )
         }
 
@@ -91,88 +93,93 @@ class PersistenceQuizViewModel @Inject constructor(
     }
 
     private fun goToNextQuestion() {
-        val currentState = _uiState.value as? PersistenceQuizUiState.Success ?: return
-        val nextQuestionIndex = currentState.currentQuestionIndex + 1
-        val isLastQuestion = nextQuestionIndex >= currentState.quizzes.size
+        val currentState = _uiState.value
+        val nextIndex = currentState.currentQuestionIndex + 1
 
-        if (isLastQuestion) {
-            _uiState.update {
-                if (it is PersistenceQuizUiState.Success) {
-                    it.copy(showResultDialog = false, dialogResult = null)
-                } else {
-                    it
-                }
-            }
-
-            viewModelScope.launch {
-                delay(DIALOG_DISMISS_ANIMATION_MS)
-                exitQuiz()
-            }
+        if (nextIndex >= currentState.quizzes.size) {
+            submitQuizResult(currentState.correctCount, currentState.quizzes.size)
         } else {
-            _uiState.update {
-                if (it is PersistenceQuizUiState.Success) {
-                    it.copy(
-                        currentQuestionIndex = nextQuestionIndex,
-                        selectedAnswerIndex = null,
-                        showResultDialog = false,
-                        dialogResult = null,
-                    )
-                } else {
-                    it
-                }
+            _uiState.update { state ->
+                state.copy(
+                    currentQuestionIndex = nextIndex,
+                    selectedAnswerIndex = null,
+                    showResultDialog = false,
+                    quizResult = null,
+                )
             }
+        }
+    }
+
+    private fun submitQuizResult(correctCount: Int, totalCount: Int) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            val result = QuizScore(
+                totalNumber = totalCount,
+                correctNumber = correctCount,
+                type = QuizCategory.PERSISTENCE,
+            )
+
+            uploadQuizScoreUseCase(result)
+                .onSuccess { exitQuiz() }
+                .onFailure { t ->
+                    Timber.e(t, "Failed to submit quiz result")
+                    _uiState.update { it.copy(isLoading = false, errorMessage = "결과 전송 실패") }
+                    exitQuiz()
+                }
         }
     }
 
     fun onBackClick() {
-        _uiState.update {
-            if (it is PersistenceQuizUiState.Success && !it.exitDialog) {
-                it.copy(exitDialog = true)
-            } else {
-                it
-            }
-        }
+        _uiState.update { it.copy(showExitDialog = true) }
     }
 
     fun onHideExitDialog() {
-        _uiState.update {
-            if (it is PersistenceQuizUiState.Success && it.exitDialog) {
-                it.copy(exitDialog = false)
-            } else {
-                it
-            }
-        }
+        _uiState.update { it.copy(showExitDialog = false) }
     }
 
     fun exitQuiz() = navigator.navigateBack()
 
     companion object {
         private const val DIALOG_DURATION_MS = 2000L
-        private const val DIALOG_DISMISS_ANIMATION_MS = 200L
     }
 }
 
 @Immutable
-sealed interface PersistenceQuizUiState {
-    data object Loading : PersistenceQuizUiState
-    data class Error(val message: String) : PersistenceQuizUiState
-    data class Success(
-        val quizzes: ImmutableList<PersistenceQuiz>,
-        val currentQuestionIndex: Int = 0,
-        val selectedAnswerIndex: Int? = null,
-        val showResultDialog: Boolean = false,
-        val dialogResult: DialogResult? = null,
-        val exitDialog: Boolean = false,
-    ) : PersistenceQuizUiState {
-        val currentStep: Int
-            get() = currentQuestionIndex + 1
+data class PersistenceQuizUiState(
+    val isLoading: Boolean,
+    val errorMessage: String?,
+    val quizzes: ImmutableList<PersistenceQuiz>,
+    val currentQuestionIndex: Int,
+    val selectedAnswerIndex: Int?,
+    val showResultDialog: Boolean,
+    val showExitDialog: Boolean,
+    val quizResult: QuizResult?,
+    val correctCount: Int,
+) {
+    val currentQuiz: PersistenceQuiz?
+        get() = quizzes.getOrNull(currentQuestionIndex)
 
-        val totalSteps: Int
-            get() = quizzes.size
+    val currentStep: Int
+        get() = currentQuestionIndex + 1
 
-        val isContinueButtonEnabled: Boolean
-            get() = selectedAnswerIndex != null && !showResultDialog
+    val totalSteps: Int
+        get() = quizzes.size
+
+    val isContinueButtonEnabled: Boolean
+        get() = selectedAnswerIndex != null && !showResultDialog
+
+    companion object {
+        val INIT = PersistenceQuizUiState(
+            isLoading = false,
+            errorMessage = null,
+            quizzes = persistentListOf(),
+            currentQuestionIndex = 0,
+            selectedAnswerIndex = null,
+            showResultDialog = false,
+            showExitDialog = false,
+            quizResult = null,
+            correctCount = 0,
+        )
     }
 }
-
-data class DialogResult(val isCorrect: Boolean, val correctAnswer: String)


### PR DESCRIPTION
## Related issue 🛠
- closed #62

## Work Description ✏️
- 지남력 퀴즈 입력 폼을 컴포넌트로 분리했습니다.
- 지남력 퀴즈 uiState 변경했습니다.(기존 interface 기반 -> data class 기반)
- 결과 제출 api를 연동했습니다.

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 퀴즈 질문 표시 및 선택 가능한 답변 옵션 UI 추가
  * 퀴즈 슬라이드 애니메이션 효과 추가
  * 퀴즈 완료 후 점수 제출 기능 추가

* **리팩토링**
  * 퀴즈 화면 상태 관리 구조 개선 및 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->