### PR TITLE
[Refactor/#69] 시니어 로그아웃, 회원탈퇴 로직 흐름을 변경합니다.

### DIFF
--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/SeniorSettingScreen.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/SeniorSettingScreen.kt
@@ -18,37 +18,19 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.moa.app.designsystem.component.product.dialog.MaAlertDialog
+import com.moa.app.designsystem.component.product.dialog.MaConfirmDialog
 import com.moa.app.designsystem.component.product.setting.ProfileSection
 import com.moa.app.designsystem.component.product.topbar.MaTopAppBar
 import com.moa.app.designsystem.theme.MoaTheme
 import com.moa.app.designsystem.component.product.setting.OtherSection
 import com.moa.app.feature.senior.setting.model.SeniorSettingUiState
+import com.moa.app.feature.senior.setting.model.SettingDialogState
 
 @Composable
 fun SeniorSettingScreen(
     viewModel: SeniorSettingViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    if (uiState.showLogoutDialog) {
-        MaAlertDialog(
-            title = "로그아웃 하시겠습니까?",
-            confirmButtonText = "로그아웃 하기",
-            dismissButtonText = "취소",
-            onConfirm = viewModel::logOut,
-            onDismiss = viewModel::hideLogoutDialog,
-        )
-    }
-
-    if (uiState.showWithdrawalDialog) {
-        MaAlertDialog(
-            title = "회원탈퇴 하시겠습니까?",
-            confirmButtonText = "탈퇴하기",
-            dismissButtonText = "취소",
-            onConfirm = viewModel::withdrawal,
-            onDismiss = viewModel::hideWithdrawalDialog,
-        )
-    }
 
     SeniorSettingContent(
         uiState = uiState,
@@ -58,6 +40,50 @@ fun SeniorSettingScreen(
         onWithdrawalClick = viewModel::showWithdrawalDialog,
         onBackClick = viewModel::navigateToBack
     )
+
+    when (uiState.logoutDialogState) {
+        is SettingDialogState.None -> Unit
+        is SettingDialogState.Confirm -> {
+            MaAlertDialog(
+                title = "로그아웃 하시겠습니까?",
+                confirmButtonText = "로그아웃 하기",
+                dismissButtonText = "취소",
+                onConfirm = viewModel::logout,
+                onDismiss = viewModel::hideLogoutDialog,
+            )
+        }
+
+        is SettingDialogState.Complete -> {
+            MaConfirmDialog(
+                title = "로그아웃 완료되었습니다",
+                confirmButtonText = "확인",
+                onConfirm = viewModel::navigateToClear,
+                onDialogDismissRequest = {},
+            )
+        }
+    }
+
+    when (uiState.withdrawalDialogState) {
+        is SettingDialogState.None -> Unit
+        is SettingDialogState.Confirm -> {
+            MaAlertDialog(
+                title = "회원탈퇴 하시겠습니까?",
+                confirmButtonText = "탈퇴하기",
+                dismissButtonText = "취소",
+                onConfirm = viewModel::withdrawal,
+                onDismiss = viewModel::hideWithdrawalDialog,
+            )
+        }
+
+        is SettingDialogState.Complete -> {
+            MaConfirmDialog(
+                title = "회원탈퇴 완료되었습니다",
+                confirmButtonText = "확인",
+                onConfirm = viewModel::navigateToClear,
+                onDialogDismissRequest = {},
+            )
+        }
+    }
 }
 
 @Composable

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/SeniorSettingViewModel.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/SeniorSettingViewModel.kt
@@ -6,6 +6,7 @@ import com.moa.app.domain.auth.usecase.LogOutUseCase
 import com.moa.app.domain.auth.usecase.WithdrawalUseCase
 import com.moa.app.domain.user.usecase.FetchUserProfileUseCase
 import com.moa.app.feature.senior.setting.model.SeniorSettingUiState
+import com.moa.app.feature.senior.setting.model.SettingDialogState
 import com.moa.app.navigation.AppRoute
 import com.moa.app.navigation.NavigationOptions
 import com.moa.app.navigation.Navigator
@@ -34,45 +35,56 @@ class SeniorSettingViewModel @Inject constructor(
     }
 
     fun showLogoutDialog() {
-        _uiState.update { it.copy(showLogoutDialog = true) }
+        _uiState.update { it.copy(logoutDialogState = SettingDialogState.Confirm) }
     }
 
     fun hideLogoutDialog() {
-        _uiState.update { it.copy(showLogoutDialog = false) }
+        _uiState.update { it.copy(logoutDialogState = SettingDialogState.None) }
     }
 
     fun showWithdrawalDialog() {
-        _uiState.update { it.copy(showWithdrawalDialog = true) }
+        _uiState.update { it.copy(withdrawalDialogState = SettingDialogState.Confirm) }
     }
 
     fun hideWithdrawalDialog() {
-        _uiState.update { it.copy(showWithdrawalDialog = false) }
+        _uiState.update { it.copy(withdrawalDialogState = SettingDialogState.None) }
     }
 
     private fun fetchUserProfile() {
         viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
             fetchUserProfileUseCase().fold(
                 onSuccess = { userProfile ->
                     _uiState.update {
-                        it.copy(userName = userProfile.name, userCode = userProfile.authCode)
+                        it.copy(
+                            isLoading = false,
+                            userName = userProfile.name,
+                            userCode = userProfile.authCode,
+                        )
                     }
                 },
-                onFailure = {
-                    Timber.tag("fetchUserProfile").e("fetchUserProfile: $it")
+                onFailure = { t ->
+                    Timber.e("fetchUserProfile: $t")
+                    _uiState.update { it.copy(isLoading = false) }
                 },
             )
         }
     }
 
-    fun logOut() {
+    fun logout() {
         viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
             logOutUseCase().fold(
                 onSuccess = {
-                    navigateToClear()
+                    _uiState.update {
+                        it.copy(isLoading = false, logoutDialogState = SettingDialogState.Complete)
+                    }
                 },
-                onFailure = {
-                    Timber.tag("logOut").e("logOut: $it")
-                    hideLogoutDialog()
+                onFailure = { t ->
+                    Timber.e("Logout Failed: $t")
+                    _uiState.update {
+                        it.copy(isLoading = false, logoutDialogState = SettingDialogState.None)
+                    }
                 },
             )
         }
@@ -80,13 +92,18 @@ class SeniorSettingViewModel @Inject constructor(
 
     fun withdrawal() {
         viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
             withdrawalUseCase().fold(
                 onSuccess = {
-                    navigateToClear()
+                    _uiState.update {
+                        it.copy(isLoading = false, withdrawalDialogState = SettingDialogState.Complete)
+                    }
                 },
-                onFailure = {
-                    Timber.tag("withdrawal").e("withdrawal: $it")
-                    hideWithdrawalDialog()
+                onFailure = { t ->
+                    Timber.e("Withdrawal Failed: $t")
+                    _uiState.update {
+                        it.copy(isLoading = false, withdrawalDialogState = SettingDialogState.None)
+                    }
                 },
             )
         }
@@ -98,7 +115,7 @@ class SeniorSettingViewModel @Inject constructor(
 
     fun navigateToBack() = navigator.navigateBack()
 
-    private fun navigateToClear() {
+    fun navigateToClear() {
         navigator.navigate(
             route = AppRoute.AuthLanding,
             options = NavigationOptions(
@@ -110,7 +127,8 @@ class SeniorSettingViewModel @Inject constructor(
     }
 
     companion object {
-        private const val POLICY_URL = "https://woongaaaa.notion.site/Legal-2b41a839ca3c80bcb357fd347f9535f3"
+        private const val POLICY_URL =
+            "https://woongaaaa.notion.site/Legal-2b41a839ca3c80bcb357fd347f9535f3"
         private const val CUSTOMER_CENTER_URL = "https://pf.kakao.com/_XxaxbYn/chat"
     }
 }

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/model/SeniorSettingUiState.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/model/SeniorSettingUiState.kt
@@ -1,17 +1,19 @@
 package com.moa.app.feature.senior.setting.model
 
 data class SeniorSettingUiState(
+    val isLoading: Boolean,
     val userName: String,
     val userCode: String,
-    val showLogoutDialog: Boolean,
-    val showWithdrawalDialog: Boolean,
+    val withdrawalDialogState: SettingDialogState,
+    val logoutDialogState: SettingDialogState,
 ) {
     companion object {
         val INIT = SeniorSettingUiState(
+            isLoading = false,
             userName = "",
             userCode = "",
-            showLogoutDialog = false,
-            showWithdrawalDialog = false,
+            withdrawalDialogState = SettingDialogState.None,
+            logoutDialogState = SettingDialogState.None,
         )
     }
 }

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/model/SettingDialogState.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/setting/model/SettingDialogState.kt
@@ -1,0 +1,10 @@
+package com.moa.app.feature.senior.setting.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+interface SettingDialogState {
+    data object None : SettingDialogState
+    data object Confirm : SettingDialogState
+    data object Complete : SettingDialogState
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #69 

## Work Description ✏️
- 시니어 로그아웃, 회원탈퇴 로직 흐름을 변경했습니다.
  - 기존 -> 즉시 로그아웃 및 회원탈퇴
  - 수정 -> 다이얼로그를 통한 "확인" 뎁스 추가

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 로그아웃 및 계정 탈퇴 프로세스 중 로딩 상태 표시 추가
  * 대화상자 상태 관리 개선으로 더 안정적인 사용자 경험 제공
  * 오류 처리 강화로 예외 상황에 대한 예외 처리 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->