### PR TITLE
[Fix/#75] 기억력 퀴즈에 누락된 STT StopListening 로직을 추가합니다. 

### DIFF
--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/daily/DailyQuizViewModel.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/daily/DailyQuizViewModel.kt
@@ -95,6 +95,7 @@ class DailyQuizViewModel @Inject constructor(
                     is SttState.Speaking -> _uiState.update { it.copy(isSpeaking = true) }
                     is SttState.Success -> {
                         Timber.d("STT Success: ${state.result}")
+                        sttManager.stopListening()
                         checkAnswer(state.result)
                     }
 

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/memory/MemoryQuizScreen.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/memory/MemoryQuizScreen.kt
@@ -106,7 +106,7 @@ private fun MemoryQuizContent(
                     MemoryQuizSetState.QUESTION_DISPLAY -> {
                         MemoryQuizPlayContent(
                             imageUrls = targetQuiz.imageUrls,
-                            onImagesFinished = onImagesFinished
+                            onImagesFinished = onImagesFinished,
                         )
                     }
 
@@ -127,9 +127,7 @@ private fun MemoryQuizContent(
                                     modifier = Modifier.padding(horizontal = 20.dp),
                                     onContinueClick = onContinueTextClick,
                                     answers = uiState.userTextAnswers,
-                                    onTextAnswerChange = { index, answer ->
-                                        onTextAnswerChange(index, answer)
-                                    }
+                                    onTextAnswerChange = onTextAnswerChange,
                                 )
                             }
                         }
@@ -153,11 +151,7 @@ private fun MemoryQuizContentPreview() {
                     questionFormat = "",
                     questionContent = "",
                     answer = listOf("사과", "당근", "의자"),
-                    imageUrls = listOf(
-                        "https://moa-bucket-s3.s3.ap-northeast-2.amazonaws.com/8d120aaa-0_memory_2.png",
-                        "https://moa-bucket-s3.s3.ap-northeast-2.amazonaws.com/03548c44-e_memory_4.png",
-                        "https://moa-bucket-s3.s3.ap-northeast-2.amazonaws.com/37300c63-c_memory_8.png",
-                    ),
+                    imageUrls = listOf("", "", ""),
                 ),
             ),
         ),

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/memory/MemoryQuizViewModel.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/quiz/memory/MemoryQuizViewModel.kt
@@ -71,6 +71,7 @@ class MemoryQuizViewModel @Inject constructor(
                     is SttState.Speaking -> _uiState.update { it.copy(isSpeaking = true) }
                     is SttState.Success -> {
                         Timber.d("STT Success: ${state.result}")
+                        sttManager.stopListening()
                         checkAnswer(state.result)
                     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #75 

## Work Description ✏️
- 기억력 퀴즈 정답 STT 발화 이후 stop 로직이 누락되어 있던 문제를 수정했습니다.

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 음성 인식 기능에서 음성 입력이 감지된 즉시 수신을 중지하도록 개선되었습니다. 이로 인해 감지된 입력 이후의 불필요한 음성 인식 이벤트가 처리되지 않으며, 사용자의 답변 확인 절차가 더욱 정확하고 안정적으로 수행됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->