### PR TITLE
[Refactor/#74] 로그인 성공/실패 로직을 개선합니다.

### DIFF
--- a/core/designsystem/src/main/kotlin/com/moa/app/designsystem/component/core/button/MaButton.kt
+++ b/core/designsystem/src/main/kotlin/com/moa/app/designsystem/component/core/button/MaButton.kt
@@ -1,7 +1,6 @@
 package com.moa.app.designsystem.component.core.button
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
@@ -26,6 +25,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.moa.app.designsystem.theme.MoaTheme
+import com.moa.app.ui.extension.clickableWithoutRipple
 
 @Composable
 fun MaButton(
@@ -53,11 +53,10 @@ fun MaButton(
         modifier = modifier
             .semantics { role = Role.Button }
             .background(color = backgroundColor, shape = shape)
-            .clickable(
+            .clickableWithoutRipple(
                 enabled = enabled,
                 onClick = onClick,
                 interactionSource = interactionSource,
-                indication = null,
             ),
         contentAlignment = Alignment.Center,
     ) {

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signin/SignInScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signin/SignInScreen.kt
@@ -111,7 +111,7 @@ private fun SignInScreenContent(
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                     placeholder = {
                         Text(
-                            text = "예) 010-1234-5678",
+                            text = "예) 01012345678",
                             color = MoaTheme.colors.coolGray60,
                             style = MoaTheme.typography.body1Medium,
                         )
@@ -119,7 +119,6 @@ private fun SignInScreenContent(
                     trailingContent = {
                         MaButton(
                             onClick = onAuthCodeRequestClick,
-                            enabled = !uiState.isAuthCodeRequested,
                             colors = MaButtonDefaults.maBlackButtonColors(),
                             shape = RoundedCornerShape(8.dp)
                         ) {

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signin/SignInViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signin/SignInViewModel.kt
@@ -1,6 +1,5 @@
 package com.moa.app.feature.onboarding.signin
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.moa.app.domain.auth.model.UserRole
@@ -30,7 +29,7 @@ class SignInViewModel @Inject constructor(
     private val signInUseCase: SignInUseCase,
 ) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<SignInUiState> = MutableStateFlow(SignInUiState.init)
+    private val _uiState = MutableStateFlow(SignInUiState.init)
     val uiState: StateFlow<SignInUiState> = _uiState.asStateFlow()
 
     private val _sideEffect: MutableSharedFlow<SignInSideEffect> = MutableSharedFlow()
@@ -46,41 +45,45 @@ class SignInViewModel @Inject constructor(
 
     fun requestAuthCode() {
         viewModelScope.launch {
-            phoneAuthCodeUseCase(phoneNumber = _uiState.value.phoneNumber, isUserRegistered = true)
-                .fold(
-                    onSuccess = {
-                        _uiState.update { it.copy(isAuthCodeRequested = true) }
-                        _sideEffect.emit(SignInSideEffect.FocusOnAuthCodeField)
-                    },
-                    onFailure = { error ->
-                        _uiState.update {
-                            it.copy(
-                                isPhoneNumberError = true,
-                                phoneNumberErrorMessage = "인증번호 요청에 실패했습니다.",
-                            )
-                        }
-                        Timber.tag("SignInViewModel").e("requestAuthCode: $error")
-                    },
-                )
+            if (_uiState.value.isLoading) return@launch
+            _uiState.update { it.copy(isLoading = true) }
+            phoneAuthCodeUseCase(
+                phoneNumber = _uiState.value.phoneNumber,
+                isUserRegistered = true,
+            ).fold(
+                onSuccess = {
+                    _uiState.update { it.copy(isLoading = false, isAuthCodeRequested = true) }
+                    _sideEffect.emit(SignInSideEffect.FocusOnAuthCodeField)
+                },
+                onFailure = { error ->
+                    Timber.e("requestAuthCode: $error")
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            isPhoneNumberError = true,
+                            phoneNumberErrorMessage = "인증번호 요청에 실패했습니다.",
+                        )
+                    }
+                },
+            )
         }
     }
 
     fun signIn() {
         viewModelScope.launch {
+            if (_uiState.value.isLoading) return@launch
             val phoneNumber = _uiState.value.phoneNumber
             val authCode = _uiState.value.authCode
             signInUseCase(phoneNumber, authCode).fold(
-                onSuccess = { userRole ->
-                    handleNavigationForRole(userRole)
-                },
-                onFailure = { t ->
+                onSuccess = { userRole -> handleNavigationForRole(userRole) },
+                onFailure = { error ->
+                    Timber.e("signIn: $error")
                     _uiState.update {
                         it.copy(
                             isAuthCodeError = true,
                             authCodeErrorMessage = "인증번호가 일치하지 않아요.\n다시 확인해주세요.",
                         )
                     }
-                    Timber.tag("SignInViewModel").e("signIn: $t")
                 },
             )
         }
@@ -89,7 +92,7 @@ class SignInViewModel @Inject constructor(
     private fun handleNavigationForRole(userRole: UserRole) {
         when (userRole) {
             UserRole.PARENT -> navigateToRoute(AppRoute.SeniorHome)
-            UserRole.CHILD -> {}
+            UserRole.CHILD -> navigateToRoute(AppRoute.GuardianHome)
             UserRole.PENDING -> navigateToRoute(AppRoute.SelectUserRole)
             else -> {}
         }

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signin/model/SignInUiState.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signin/model/SignInUiState.kt
@@ -1,6 +1,7 @@
 package com.moa.app.feature.onboarding.signin.model
 
 data class SignInUiState(
+    val isLoading: Boolean,
     val phoneNumber: String,
     val authCode: String,
     val isAuthCodeRequested: Boolean,
@@ -11,6 +12,7 @@ data class SignInUiState(
 ) {
     companion object {
         val init = SignInUiState(
+            isLoading = false,
             phoneNumber = "",
             authCode = "",
             isAuthCodeRequested = false,

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signup/SignUpPhoneAuthScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signup/SignUpPhoneAuthScreen.kt
@@ -113,7 +113,7 @@ private fun SignUpPhoneAuthScreenContent(
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                     placeholder = {
                         Text(
-                            text = "예) 010-1234-5678",
+                            text = "예) 01012345678",
                             color = MoaTheme.colors.coolGray60,
                             style = MoaTheme.typography.body1Medium,
                         )
@@ -121,7 +121,6 @@ private fun SignUpPhoneAuthScreenContent(
                     trailingContent = {
                         MaButton(
                             onClick = onAuthCodeRequestClick,
-                            enabled = !uiState.isAuthCodeRequested,
                             colors = MaButtonDefaults.maBlackButtonColors(),
                             shape = RoundedCornerShape(8.dp)
                         ) {

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signup/SignUpSharedViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signup/SignUpSharedViewModel.kt
@@ -75,18 +75,22 @@ class SignUpSharedViewModel @Inject constructor(
 
     fun requestPhoneAuthCode() {
         viewModelScope.launch {
-            phoneAuthCodeUseCase(
-                phoneNumber = _signUpPhoneAuthUiState.value.phoneNumber,
-            ).fold(
+            if (_signUpPhoneAuthUiState.value.isLoading) return@launch
+            _signUpPhoneAuthUiState.update { it.copy(isLoading = true) }
+            phoneAuthCodeUseCase(phoneNumber = _signUpPhoneAuthUiState.value.phoneNumber).fold(
                 onSuccess = {
-                    _signUpPhoneAuthUiState.update { it.copy(isAuthCodeRequested = true) }
+                    _signUpPhoneAuthUiState.update { it.copy(isLoading = false, isAuthCodeRequested = true) }
                     _signUpPhoneAuthSideEffect.emit(SignUpPhoneAuthSideEffect.FocusOnAuthCodeField)
                 },
                 onFailure = { error ->
+                    Timber.e("requestPhoneAuthCode error: $error")
                     _signUpPhoneAuthUiState.update {
-                        it.copy(isPhoneNumberError = true, phoneNumberErrorMessage = error.message)
+                        it.copy(
+                            isLoading = false,
+                            isPhoneNumberError = true,
+                            phoneNumberErrorMessage = "인증번호 요청에 실패했습니다.",
+                        )
                     }
-                    Timber.tag("SignUpSharedViewModel").e("requestAuthCode: $error")
                 },
             )
         }
@@ -94,7 +98,9 @@ class SignUpSharedViewModel @Inject constructor(
 
     fun signUp() {
         viewModelScope.launch {
+            if (_signUpPhoneAuthUiState.value.isLoading) return@launch
             val gender = _signUpUserProfileUiState.value.gender ?: return@launch
+            _signUpPhoneAuthUiState.update { it.copy(isLoading = true) }
             signUpUseCase(
                 userProfile = UserProfile(
                     name = _signUpUserProfileUiState.value.name,
@@ -107,7 +113,11 @@ class SignUpSharedViewModel @Inject constructor(
                 onSuccess = { navigateToComplete() },
                 onFailure = { error ->
                     _signUpPhoneAuthUiState.update {
-                        it.copy(isAuthCodeError = true, authCodeErrorMessage = error.message)
+                        it.copy(
+                            isLoading = false,
+                            isAuthCodeError = true,
+                            authCodeErrorMessage = "인증번호가 일치하지 않아요.\n다시 확인해주세요."
+                        )
                     }
                 },
             )

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signup/model/SignUpPhoneAuthUiState.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/signup/model/SignUpPhoneAuthUiState.kt
@@ -1,6 +1,7 @@
 package com.moa.app.feature.onboarding.signup.model
 
 data class SignUpPhoneAuthUiState(
+    val isLoading: Boolean,
     val phoneNumber: String,
     val authCode: String,
     val isAuthCodeRequested: Boolean,
@@ -11,6 +12,7 @@ data class SignUpPhoneAuthUiState(
 ) {
     companion object {
         val init = SignUpPhoneAuthUiState(
+            isLoading = false,
             phoneNumber = "",
             authCode = "",
             isAuthCodeRequested = false,

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/splash/SplashViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/splash/SplashViewModel.kt
@@ -58,7 +58,8 @@ class SplashViewModel @Inject constructor(
             route = route,
             options = NavigationOptions(
                 popUpTo = AppRoute.Splash,
-                inclusive = true
+                inclusive = true,
+                clearBackStack = true
             )
         )
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #74 

## Work Description ✏️
- 로그인 성공/실패 로직을 개선했습니다.
- 로그인/회원가입 화면에서 인증번호 재요청이 되지 않던 이슈 수정

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 회원가입 및 로그인 중 로딩 상태 추가로 사용자 경험 개선

* **버그 수정**
  * 인증 요청 중 재시도 방지 로직 강화
  * 오류 메시지 처리 및 표시 개선
  * 자식 계정 네비게이션 흐름 수정
  * 백스택 관리 개선

* **스타일**
  * 휴대폰 번호 입력 필드 플레이스홀더 형식 변경 (010-1234-5678 → 01012345678)
  * 버튼 터치 반응 효과 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->