### PR TITLE
[Refactor/#92] 네비게이션 구조 개선

### DIFF
--- a/app/src/main/kotlin/com/moa/app/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/moa/app/main/MainActivity.kt
@@ -6,42 +6,16 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import com.moa.app.designsystem.theme.MoATheme
 import com.moa.app.designsystem.theme.MoaTheme
-import com.moa.app.feature.guardian.alert.GuardianAlertScreen
-import com.moa.app.feature.guardian.home.GuardianHomeScreen
-import com.moa.app.feature.guardian.setting.GuardianSettingScreen
-import com.moa.app.feature.onboarding.connection.ConnectionCheckScreen
-import com.moa.app.feature.onboarding.connection.UserConnectionScreen
-import com.moa.app.feature.onboarding.landing.AuthLandingScreen
-import com.moa.app.feature.onboarding.role.SelectUserRoleScreen
-import com.moa.app.feature.onboarding.signin.SignInScreen
-import com.moa.app.feature.onboarding.signup.SignUpCompleteScreen
-import com.moa.app.feature.onboarding.signup.SignUpPhoneAuthScreen
-import com.moa.app.feature.onboarding.signup.SignUpProfileScreen
-import com.moa.app.feature.onboarding.signup.SignUpSharedViewModel
-import com.moa.app.feature.onboarding.splash.SplashScreen
-import com.moa.app.feature.report.ReportScreen
-import com.moa.app.feature.senior.home.SeniorHomeScreen
-import com.moa.app.feature.senior.quiz.attention.AttentionQuizScreen
-import com.moa.app.feature.senior.quiz.category.QuizCategoryScreen
-import com.moa.app.feature.senior.quiz.daily.DailyQuizScreen
-import com.moa.app.feature.senior.quiz.linguistic.LinguisticQuizScreen
-import com.moa.app.feature.senior.quiz.memory.MemoryQuizScreen
-import com.moa.app.feature.senior.quiz.persistence.PersistenceQuizScreen
-import com.moa.app.feature.senior.quiz.spacetime.SpaceTimeQuizScreen
-import com.moa.app.feature.senior.setting.SeniorSettingScreen
+import com.moa.app.feature.guardian.guardianGraph
+import com.moa.app.feature.onboarding.onboardingGraph
+import com.moa.app.feature.report.reportGraph
+import com.moa.app.feature.senior.seniorGraph
 import com.moa.app.navigation.AppRoute
 import com.moa.app.navigation.ObserveNavigationEvents
 import dagger.hilt.android.AndroidEntryPoint
@@ -66,48 +40,13 @@ class MainActivity : ComponentActivity() {
                         startDestination = AppRoute.Splash,
                         modifier = Modifier.padding(innerPadding),
                     ) {
-                        composable<AppRoute.Splash> { SplashScreen() }
-                        composable<AppRoute.AuthLanding> { AuthLandingScreen() }
-                        composable<AppRoute.SignIn> { SignInScreen() }
-                        navigation<AppRoute.SignUp>(
-                            startDestination = AppRoute.SignUpProfile
-                        ) {
-                            composable<AppRoute.SignUpProfile> { backStackEntry ->
-                                val viewModel = backStackEntry.sharedViewModel<SignUpSharedViewModel>(navController)
-                                SignUpProfileScreen(viewModel)
-                            }
-                            composable<AppRoute.SignUpPhoneAuth> { backStackEntry ->
-                                val viewModel = backStackEntry.sharedViewModel<SignUpSharedViewModel>(navController)
-                                SignUpPhoneAuthScreen(viewModel)
-                            }
-                            composable<AppRoute.SignUpComplete> { SignUpCompleteScreen() }
-                        }
-                        composable<AppRoute.SelectUserRole> { SelectUserRoleScreen() }
-                        composable<AppRoute.UserConnection> { UserConnectionScreen() }
-                        composable<AppRoute.ConnectionCheck> { ConnectionCheckScreen() }
-                        composable<AppRoute.SeniorHome> { SeniorHomeScreen() }
-                        composable<AppRoute.QuizCategory> { QuizCategoryScreen() }
-                        composable<AppRoute.PersistenceQuiz> { PersistenceQuizScreen() }
-                        composable<AppRoute.LinguisticQuiz> { LinguisticQuizScreen() }
-                        composable<AppRoute.AttentionQuiz> { AttentionQuizScreen() }
-                        composable<AppRoute.SpaceTimeQuiz> { SpaceTimeQuizScreen() }
-                        composable<AppRoute.MemoryQuiz> { MemoryQuizScreen() }
-                        composable<AppRoute.DailyQuiz> { DailyQuizScreen() }
-                        composable<AppRoute.SeniorSetting> { SeniorSettingScreen() }
-                        composable<AppRoute.Report> { ReportScreen() }
-                        composable<AppRoute.GuardianHome> { GuardianHomeScreen() }
-                        composable<AppRoute.GuardianSetting> { GuardianSettingScreen() }
-                        composable<AppRoute.GuardianAlert> { GuardianAlertScreen() }
+                        onboardingGraph(navController)
+                        seniorGraph()
+                        guardianGraph()
+                        reportGraph()
                     }
                 }
             }
         }
     }
-}
-
-@Composable
-internal inline fun <reified T : ViewModel> NavBackStackEntry.sharedViewModel(navController: NavController): T {
-    val navGraphRoute = destination.parent?.route ?: return hiltViewModel()
-    val parentEntry = remember(this) { navController.getBackStackEntry(navGraphRoute) }
-    return hiltViewModel(parentEntry)
 }

--- a/app/src/main/kotlin/com/moa/app/navigation/ObserveNavigationEvents.kt
+++ b/app/src/main/kotlin/com/moa/app/navigation/ObserveNavigationEvents.kt
@@ -1,15 +1,13 @@
 package com.moa.app.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import com.moa.app.main.MainViewModel
-import kotlinx.coroutines.launch
 
 @Composable
 internal fun ObserveNavigationEvents(
@@ -19,36 +17,32 @@ internal fun ObserveNavigationEvents(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    DisposableEffect(lifecycleOwner, navController) {
-        val job = lifecycleOwner.lifecycleScope.launch {
-            lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.navigationEvents.collect { event ->
-                    when (event) {
-                        is NavigationEvent.NavigateBack -> navController.popBackStack()
-                        is NavigationEvent.OpenUrl -> openUrlInBrowser(context, event.url)
-                        is NavigationEvent.Navigate -> {
-                            navController.navigate(event.route) {
-                                if (event.options.clearBackStack) {
-                                    popUpTo(navController.graph.id) {
-                                        inclusive = true
-                                    }
-                                } else {
-                                    event.options.popUpTo?.let { popUpToRoute ->
-                                        popUpTo(popUpToRoute) {
-                                            inclusive = event.options.inclusive
-                                            saveState = event.options.saveState
-                                        }
+    LaunchedEffect(viewModel.navigationEvents, lifecycleOwner) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.navigationEvents.collect { event ->
+                when (event) {
+                    is NavigationEvent.NavigateBack -> navController.popBackStack()
+                    is NavigationEvent.OpenUrl -> openUrlInBrowser(context, event.url)
+                    is NavigationEvent.Navigate -> {
+                        navController.navigate(event.route) {
+                            if (event.options.clearBackStack) {
+                                popUpTo(navController.graph.id) {
+                                    inclusive = true
+                                }
+                            } else {
+                                event.options.popUpTo?.let { popUpToRoute ->
+                                    popUpTo(popUpToRoute) {
+                                        inclusive = event.options.inclusive
+                                        saveState = event.options.saveState
                                     }
                                 }
-                                launchSingleTop = event.options.launchSingleTop
-                                restoreState = event.options.restoreState
                             }
+                            launchSingleTop = event.options.launchSingleTop
+                            restoreState = event.options.restoreState
                         }
                     }
                 }
             }
         }
-
-        onDispose { job.cancel() }
     }
 }

--- a/core/ui/src/main/java/com/moa/app/ui/extension/NavBackStackEntry.kt
+++ b/core/ui/src/main/java/com/moa/app/ui/extension/NavBackStackEntry.kt
@@ -1,0 +1,19 @@
+package com.moa.app.ui.extension
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+
+/**
+ * [NavBackStackEntry]에서 부모 [NavGraph]의 [ViewModel]을 가져오기 위한 확장 함수입니다.
+ * 만약 부모 [NavGraph]가 없을 경우, 현재 [NavBackStackEntry]를 기준으로 [ViewModel]을 생성합니다.
+ */
+@Composable
+inline fun <reified T : ViewModel> NavBackStackEntry.sharedViewModel(navController: NavController): T {
+    val navGraphRoute = destination.parent?.route ?: return hiltViewModel()
+    val parentEntry = remember(this) { navController.getBackStackEntry(navGraphRoute) }
+    return hiltViewModel(parentEntry)
+}

--- a/feature/guardian/src/main/kotlin/com/moa/app/feature/guardian/GuardianNavigation.kt
+++ b/feature/guardian/src/main/kotlin/com/moa/app/feature/guardian/GuardianNavigation.kt
@@ -1,0 +1,14 @@
+package com.moa.app.feature.guardian
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.moa.app.feature.guardian.alert.GuardianAlertScreen
+import com.moa.app.feature.guardian.home.GuardianHomeScreen
+import com.moa.app.feature.guardian.setting.GuardianSettingScreen
+import com.moa.app.navigation.AppRoute
+
+fun NavGraphBuilder.guardianGraph() {
+    composable<AppRoute.GuardianHome> { GuardianHomeScreen() }
+    composable<AppRoute.GuardianSetting> { GuardianSettingScreen() }
+    composable<AppRoute.GuardianAlert> { GuardianAlertScreen() }
+}

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 dependencies {
     implementation(projects.core.designsystem)
     implementation(projects.core.navigation)
+    implementation(projects.core.ui)
     implementation(projects.domain)
 
     implementation(libs.timber)

--- a/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/kotlin/com/moa/app/feature/onboarding/OnboardingNavigation.kt
@@ -1,0 +1,40 @@
+package com.moa.app.feature.onboarding
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.moa.app.feature.onboarding.connection.ConnectionCheckScreen
+import com.moa.app.feature.onboarding.connection.UserConnectionScreen
+import com.moa.app.feature.onboarding.landing.AuthLandingScreen
+import com.moa.app.feature.onboarding.role.SelectUserRoleScreen
+import com.moa.app.feature.onboarding.signin.SignInScreen
+import com.moa.app.feature.onboarding.signup.SignUpCompleteScreen
+import com.moa.app.feature.onboarding.signup.SignUpPhoneAuthScreen
+import com.moa.app.feature.onboarding.signup.SignUpProfileScreen
+import com.moa.app.feature.onboarding.signup.SignUpSharedViewModel
+import com.moa.app.feature.onboarding.splash.SplashScreen
+import com.moa.app.navigation.AppRoute
+import com.moa.app.ui.extension.sharedViewModel
+
+fun NavGraphBuilder.onboardingGraph(navController: NavController) {
+    composable<AppRoute.Splash> { SplashScreen() }
+    composable<AppRoute.AuthLanding> { AuthLandingScreen() }
+    composable<AppRoute.SignIn> { SignInScreen() }
+    navigation<AppRoute.SignUp>(
+        startDestination = AppRoute.SignUpProfile
+    ) {
+        composable<AppRoute.SignUpProfile> { backStackEntry ->
+            val viewModel = backStackEntry.sharedViewModel<SignUpSharedViewModel>(navController)
+            SignUpProfileScreen(viewModel)
+        }
+        composable<AppRoute.SignUpPhoneAuth> { backStackEntry ->
+            val viewModel = backStackEntry.sharedViewModel<SignUpSharedViewModel>(navController)
+            SignUpPhoneAuthScreen(viewModel)
+        }
+        composable<AppRoute.SignUpComplete> { SignUpCompleteScreen() }
+    }
+    composable<AppRoute.SelectUserRole> { SelectUserRoleScreen() }
+    composable<AppRoute.UserConnection> { UserConnectionScreen() }
+    composable<AppRoute.ConnectionCheck> { ConnectionCheckScreen() }
+}

--- a/feature/report/src/main/java/com/moa/app/feature/report/ReportNavigation.kt
+++ b/feature/report/src/main/java/com/moa/app/feature/report/ReportNavigation.kt
@@ -1,0 +1,9 @@
+package com.moa.app.feature.report
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.moa.app.navigation.AppRoute
+
+fun NavGraphBuilder.reportGraph() {
+    composable<AppRoute.Report> { ReportScreen() }
+}

--- a/feature/senior/src/main/kotlin/com/moa/app/feature/senior/SeniorNavigation.kt
+++ b/feature/senior/src/main/kotlin/com/moa/app/feature/senior/SeniorNavigation.kt
@@ -1,0 +1,26 @@
+package com.moa.app.feature.senior
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.moa.app.feature.senior.home.SeniorHomeScreen
+import com.moa.app.feature.senior.quiz.attention.AttentionQuizScreen
+import com.moa.app.feature.senior.quiz.category.QuizCategoryScreen
+import com.moa.app.feature.senior.quiz.daily.DailyQuizScreen
+import com.moa.app.feature.senior.quiz.linguistic.LinguisticQuizScreen
+import com.moa.app.feature.senior.quiz.memory.MemoryQuizScreen
+import com.moa.app.feature.senior.quiz.persistence.PersistenceQuizScreen
+import com.moa.app.feature.senior.quiz.spacetime.SpaceTimeQuizScreen
+import com.moa.app.feature.senior.setting.SeniorSettingScreen
+import com.moa.app.navigation.AppRoute
+
+fun NavGraphBuilder.seniorGraph() {
+    composable<AppRoute.SeniorHome> { SeniorHomeScreen() }
+    composable<AppRoute.QuizCategory> { QuizCategoryScreen() }
+    composable<AppRoute.PersistenceQuiz> { PersistenceQuizScreen() }
+    composable<AppRoute.LinguisticQuiz> { LinguisticQuizScreen() }
+    composable<AppRoute.AttentionQuiz> { AttentionQuizScreen() }
+    composable<AppRoute.SpaceTimeQuiz> { SpaceTimeQuizScreen() }
+    composable<AppRoute.MemoryQuiz> { MemoryQuizScreen() }
+    composable<AppRoute.DailyQuiz> { DailyQuizScreen() }
+    composable<AppRoute.SeniorSetting> { SeniorSettingScreen() }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #92 

## Work Description ✏️
- 각 feature 모듈에 Navigation 확장 함수(예: registerGuardianGraph)를 정의하여 NavGraphBuilder를 분리하고, 이를 app 모듈에서 조합하는 방식으로 개선합니다.
- Kotlin Serialization 기반의 Type-safe Navigation을 유지하면서 모듈 간 독립성을 확보

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- [ ] Task1
